### PR TITLE
Fix file-service tests by updating serialisation to use bincode

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/file-service.iml
+++ b/.idea/file-service.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="EMPTY_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/file-service.iml" filepath="$PROJECT_DIR$/.idea/file-service.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2018"
 failure = "0.1.2"
 file-protocol = { path = "../file-protocol" }
 # file-protocol = {git = "ssh://git@github.com/Cube-OS/file-protocol.git"}
-kubos-system = { path = "../../system-api" }
-# kubos-system = {git = "ssh://git@github.com/Cube-OS/system-api.git" }
+# kubos-system = { path = "../../system-api" }
+kubos-system = {git = "ssh://git@github.com/Cube-OS/system-api.git" }
 log = "^0.4.0"
+serde = { version = "1.0", features = ["derive"] }
+bincode = { git = "ssh://git@github.com/Cube-OS/bincode" }
 
 [dev-dependencies]
 blake2-rfc = "0.2.18"
 rand = "0.5.5"
-serde = "1.0.58"
-serde_cbor = "0.10.2"
 tempfile = "3"


### PR DESCRIPTION
Serialisation of messages was changed from CBOR to bincode in the production code, and some other method signature changes were made to `file-protocol`, but the `file-service` test code was not updated to reflect this.

This PR fixes the test code to work with the latest `file-protocol` implementation in Cube-OS.

Note that the upload tests are still not fully working - this will be addressed as #6, as the problem there seems to be unrelated to serialisation.

Also included are the RustRover project files which may be helpful for developers using the new Jetbrains IDE, including our team at Mawson.