### PR TITLE
#6 Fix upload timeouts by moving UDP bind outside recv loop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,9 @@ pub fn recv_loop(config: &ServiceConfig) -> Result<(), failure::Error> {
         hash_chunk_size,
     );
 
+    // Listen on UDP port
     // let c_protocol = cbor_protocol::Protocol::new(&host.clone(), transfer_chunk_size);
+    let host_socket = UdpSocket::bind(host.clone())?;
 
     let timeout = config
         .get("timeout")
@@ -125,9 +127,7 @@ pub fn recv_loop(config: &ServiceConfig) -> Result<(), failure::Error> {
     let threads = Arc::new(Mutex::new(raw_threads));
 
     loop {
-        // Listen on UDP port
         let mut buf = vec![0; hash_chunk_size];
-        let host_socket = UdpSocket::bind(host.clone())?;
         let (_source, first_message) = match host_socket.recv_from(&mut buf) {
             Ok((size, source)) => {
                 buf.truncate(size);


### PR DESCRIPTION
After [much debugging](https://github.com/mryall-mawson/file-service/commits/mryall/6-upload-debug-logging/), I found the problem with uploads timing out:

* [The change to bincode](https://github.com/Cube-OS/file-service/commit/1901ea5526fdb2fa7add669aa83259e69b6f026d#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759) moved the UDP socket bind from outside the recv loop into the top of the loop.
* This meant that every time a packet is received, the process rebinds the UDP port. Rebinding a port drops any packets held by the OS in its network buffer.
* In the test cases, and probably often in practice, there are two packets sent in quick succession, like the "metadata" and "export" messages sent by an upload request, then the second packet is lost and the upload times out.

The fix turned out to be simple: move the UDP port binding out of the loop.

I put the bind back to where it occurred in the old code, next to the now-commented-out line 116 which called `cbor_protocol::Protocol::new()`.